### PR TITLE
Create iPoints nested in JSON Values of Variables

### DIFF
--- a/src/main/java/extension/gql/GqlEditor.java
+++ b/src/main/java/extension/gql/GqlEditor.java
@@ -1,14 +1,12 @@
 package extension.gql;
 
 import burp.BurpExtender;
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
 import extension.utils.Logger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import extension.utils.JsonUtils;
 
 public class GqlEditor {
 
@@ -38,9 +36,17 @@ public class GqlEditor {
     String variables = original.getVariables();
     JsonParser parser = new JsonParser();
     String injectKey = injectionPoint.getName();
-    String newVariables;
-    logger.log("Preparing to inject for key: " + injectKey);
+    String injectValue = injectionPoint.getValue();
 
+    String newVariables;
+    logger.log("Preparing to inject for key: " + injectKey + "with payload " + payload);
+    JsonObject vars = parser.parse(variables).getAsJsonObject();
+
+    JsonUtils.setJsonElement(vars, injectKey, payload);
+
+    newVariables = vars.toString();
+
+    /* old garbage first attempt
     if(injectKey.contains("||"))
     {
       logger.log("inject key contains a ||  so treating as nested ");
@@ -55,7 +61,16 @@ public class GqlEditor {
 
         if(i == injectKeyList.length-1)
         {
-          nestedJson.getAsJsonObject().addProperty(injectKeyList[i], payload);
+          if(injectValue == "||array||") {
+            JsonArray oldArray = nestedJson.getAsJsonArray();
+            nestedJson.getAsJsonObject().addProperty(injectKeyList[i], payload);
+
+          }
+          else {
+            nestedJson.getAsJsonObject().addProperty(injectKeyList[i], payload);
+
+
+          }
           newVariables = vars.toString();
           logger.log("Inserted nested var: " + newVariables);
         }
@@ -74,6 +89,7 @@ public class GqlEditor {
       newVariables = vars.toString();
 
     }
+    */
     return modify(original, new GqlRequest(null, null, newVariables, null));
   }
 

--- a/src/main/java/extension/gql/GqlVariableParser.java
+++ b/src/main/java/extension/gql/GqlVariableParser.java
@@ -13,27 +13,37 @@ public class GqlVariableParser {
 
   private static Logger logger = BurpExtender.getLogger();
 
-  private void addJsonToIpoints(JsonObject vars, List<GqlVariableInjectionPoint> iPoints,String prev_key)
+  private void addJsonToIpoints(JsonElement vars, List<GqlVariableInjectionPoint> iPoints,String prev_key)
   {
-    for (Entry<String, JsonElement> element : vars.entrySet()) {
-      String key = element.getKey();
-      if (prev_key!="")
+    if(vars.isJsonObject()) {
+      for (Entry<String, JsonElement> element : vars.getAsJsonObject().entrySet()) {
+        String key = element.getKey();
+        if (prev_key != "") {
 
-      {
-        key = prev_key + "||" + key;
+          //use json paths
+          key = prev_key + "." + key;
+        }
+
+        addJsonToIpoints(element.getValue(), iPoints, key);
+
       }
-      if (element.getValue().isJsonObject())
-      {
-        JsonObject jsonValue = element.getValue().getAsJsonObject();
-        addJsonToIpoints(jsonValue, iPoints ,key);
-      }
-      else {
-        String value = element.getValue().getAsString();
-        iPoints.add(new GqlVariableInjectionPoint(key, value));
+    }else if (vars.isJsonArray()) {
+      int i = 0;
+      for (JsonElement item : vars.getAsJsonArray()) {
+
+        String arraykey = prev_key + String.format("[%d]", i);
+        addJsonToIpoints(item, iPoints, arraykey);
+        i++;
       }
     }
-
+    else if(vars.isJsonPrimitive()) {
+          String value = vars.getAsString();
+          iPoints.add(new GqlVariableInjectionPoint(prev_key, value));
+        }
   }
+
+
+
 
 
 

--- a/src/main/java/extension/gql/GqlVariableParser.java
+++ b/src/main/java/extension/gql/GqlVariableParser.java
@@ -13,6 +13,30 @@ public class GqlVariableParser {
 
   private static Logger logger = BurpExtender.getLogger();
 
+  private void addJsonToIpoints(JsonObject vars, List<GqlVariableInjectionPoint> iPoints,String prev_key)
+  {
+    for (Entry<String, JsonElement> element : vars.entrySet()) {
+      String key = element.getKey();
+      if (prev_key!="")
+
+      {
+        key = prev_key + "||" + key;
+      }
+      if (element.getValue().isJsonObject())
+      {
+        JsonObject jsonValue = element.getValue().getAsJsonObject();
+        addJsonToIpoints(jsonValue, iPoints ,key);
+      }
+      else {
+        String value = element.getValue().getAsString();
+        iPoints.add(new GqlVariableInjectionPoint(key, value));
+      }
+    }
+
+  }
+
+
+
   public List<GqlVariableInjectionPoint> extractInsertationPoints(String variables){
     if(variables == null || variables.isEmpty()) {
       return new ArrayList<>();
@@ -22,12 +46,10 @@ public class GqlVariableParser {
       JsonParser parser = new JsonParser();
       JsonObject vars = parser.parse(variables).getAsJsonObject();
 
+      logger.log("Here is the variables: " + variables);
+
       List<GqlVariableInjectionPoint> iPoints = new ArrayList<>();
-      for (Entry<String, JsonElement> element : vars.entrySet()) {
-        String key = element.getKey();
-        String value = element.getValue().getAsString();
-        iPoints.add(new GqlVariableInjectionPoint(key, value));
-      }
+      addJsonToIpoints(vars, iPoints,"");
 
       return iPoints;
 

--- a/src/main/java/extension/utils/JsonUtils.java
+++ b/src/main/java/extension/utils/JsonUtils.java
@@ -1,0 +1,80 @@
+package extension.utils;
+import com.google.gson.*;
+
+public class JsonUtils {
+    /**
+     * Returns a JSON sub-element from the given JsonElement and the given path
+     *
+     * @param json - a Gson JsonElement
+     * @param path - a JSON path, e.g. a.b.c[2].d
+     * @return - a sub-element of json according to the given path
+     */
+    public static JsonElement getJsonElement(JsonElement json, String path){
+
+        String[] parts = path.split("\\.|\\[|\\]");
+        JsonElement result = json;
+
+        for (String key : parts) {
+
+            key = key.trim();
+            if (key.isEmpty())
+                continue;
+
+            if (result == null){
+                result = JsonNull.INSTANCE;
+                break;
+            }
+
+            if (result.isJsonObject()){
+                result = ((JsonObject)result).get(key);
+            }
+            else if (result.isJsonArray()){
+                int ix = Integer.valueOf(key) - 1;
+                result = ((JsonArray)result).get(ix);
+            }
+            else break;
+        }
+
+        return result;
+    }
+
+    public static void setJsonElement(JsonElement json, String path, String payload){
+
+        String[] parts = path.split("\\.|\\[|\\]");
+        JsonElement result = json;
+
+        for (String key : parts) {
+
+            key = key.trim();
+
+            if (key.isEmpty())
+                continue;
+
+            if (result == null){
+                result = JsonNull.INSTANCE;
+                break;
+            }
+
+            if (result.isJsonObject()){
+                if(((JsonObject)result).get(key).isJsonPrimitive())
+                {
+                    ((JsonObject)result).addProperty(key, payload);
+                    return;
+                }
+                result = ((JsonObject)result).get(key);
+            }
+            else if (result.isJsonArray()){
+
+                int ix = Integer.valueOf(key) - 1;
+                if(((JsonArray)result).get(ix).isJsonPrimitive())
+                {
+                    ((JsonArray)result).set(1,  new JsonPrimitive(payload));
+                    return;
+                }
+                result = ((JsonArray)result).get(ix);
+            }
+            else break;
+        }
+
+    }
+}

--- a/src/main/java/extension/utils/JsonUtils.java
+++ b/src/main/java/extension/utils/JsonUtils.java
@@ -68,7 +68,7 @@ public class JsonUtils {
                 int ix = Integer.valueOf(key) - 1;
                 if(((JsonArray)result).get(ix).isJsonPrimitive())
                 {
-                    ((JsonArray)result).set(1,  new JsonPrimitive(payload));
+                    ((JsonArray)result).set(ix,  new JsonPrimitive(payload));
                     return;
                 }
                 result = ((JsonArray)result).get(ix);


### PR DESCRIPTION
Supports creating insertion points on Variables whose value is JSON. Will iterate through the JSON adding insertion points to every JSON primitive in the tree. 

For example

`{"testType":["test1","test2"],"test2Type":["test1"],"test3":["three"],"count":5}`
generates the following insertion points
`[var]testType[0]:index
[var]testType[1]:metric
[var]test2Type[0]:test1
[var]test3[0]:three
[var]count:5`